### PR TITLE
大佬，发现您的项目引入了org.mybatis:mybatis@3.5.3组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.crawler</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.5.3</version>
+            <version>3.5.6</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：MyBatis 代码问题漏洞
缺陷组件：org.mybatis:mybatis@3.5.3
漏洞编号：CVE-2020-26945
漏洞描述：MyBatis是美国阿帕奇（Apache）软件基金会的一款优秀的持久层框架。支持自定义 SQL、存储过程以及高级映射，免除了几乎所有的 JDBC 代码以及设置参数和获取结果集的工作， 可以通过简单的 XML 或注解来配置和映射原始类型、接口和 Java POJO（Plain Old Java Objects，普通老式 Java 对象）为数据库中的记录。
MyBatis 3.5.6之前版本存在代码问题漏洞，该漏洞源于网络系统或产品的代码开发过程中存在设计或实现不当的问题。
影响范围：(∞, 3.5.6)
最小修复版本：3.5.6
缺陷组件引入路径：com.github.crawler:es-crawler@1.0-SNAPSHOT->org.mybatis:mybatis@3.5.3
```
另外我运行这个项目时，IDE的安全插件提示还有13个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p712ee